### PR TITLE
Update pricing plans layout and add new card sections

### DIFF
--- a/cptc-CPW219-eCommerceSite/Views/Home/Index.cshtml
+++ b/cptc-CPW219-eCommerceSite/Views/Home/Index.cshtml
@@ -276,43 +276,53 @@
 
                         <h2>Pricing Plans</h2>
 
-                        <div class="d-flex flex-column flex-md-row gap-4 py-md-5 align-items-center justify-content-center">
+                        <div class="d-flex flex-column flex-md-row gap-4 py-2 align-items-center justify-content-center">
                             <div class="list-group list-group-radio d-grid gap-2 border-0">
                                 <div class="position-relative">
-                                    <input class="form-check-input position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid1" value="" checked="">
+                                    <input class="form-check-input   position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid1" value="" >
                                     <label class="list-group-item py-3 pe-5" for="listGroupRadioGrid1">
-                                        <strong class="fw-semibold">First radio</strong>
-                                        <span class="d-block small opacity-75">With support text underneath to add more detail</span>
+
+                                        <strong class="fw-semibold">Hourly Rate</strong>
+                                        <span class="d-block small opacity-75 text-start">
+                                     <ul>
+                                        <li>Ideal for small tasks, debugging, or consulting.
+                                        Example: $50–$100/hour (discount for bulk hours).</li>
+                                    </ul>
+                                    </span>                    
+
                                     </label>
                                 </div>
 
                                 <div class="position-relative">
-                                    <input class="form-check-input position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid2" value="">
+                                    <input class="form-check-input  position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid2" value="">
                                     <label class="list-group-item py-3 pe-5" for="listGroupRadioGrid2">
-                                        <strong class="fw-semibold">Second radio</strong>
-                                        <span class="d-block small opacity-75">Some other text goes here</span>
+                                        <strong class="fw-semibold">Fixed Packages (Predefined scope)</strong>
+                                        <span class="d-block small opacity-75 text-start">
+                                            <ul>
+                                                <li>Basic (e.g., simple website setup, API integration) <br /> $300 – $800</li>
+                                                <li>Standard (e.g., custom features, automation scripts) <br /> $1,000 – $3,000</li>
+                                                <li>Advanced (e.g., full-stack apps, complex systems) <br /> $3,000 – $10,000+ </li>
+                                            </ul>
+                                        </span>
                                     </label>
                                 </div>
 
                                 <div class="position-relative">
                                     <input class="form-check-input position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid3" value="">
                                     <label class="list-group-item py-3 pe-5" for="listGroupRadioGrid3">
-                                        <strong class="fw-semibold">Third radio</strong>
-                                        <span class="d-block small opacity-75">And we end with another snippet of text</span>
-                                    </label>
-                                </div>
-
-                                <div class="position-relative">
-                                    <input class="form-check-input position-absolute top-50 end-0 me-3 fs-5" type="radio" name="listGroupRadioGrid" id="listGroupRadioGrid4" value="" disabled="">
-                                    <label class="list-group-item py-3 pe-5" for="listGroupRadioGrid4">
-                                        <strong class="fw-semibold">Fourth disabled radio</strong>
-                                        <span class="d-block small opacity-75">This option is disabled</span>
+                                        <strong class="fw-semibold text-center d-block mx-auto">Subscription Model (Ongoing support & updates)</strong>
+                                        <span class="d-block small opacity-75 text-start">
+                                            <ul>
+                                                <li>Starter – Basic maintenance & minor tweaks ($X/month)</li>
+                                                <li>Growth – Monthly feature updates & optimizations ($XX/month)</li>
+                                                <li>Premium – Full support & priority service ($XXX/month)</li>
+                                            </ul>
+                                        </span>
                                     </label>
                                 </div>
                             </div>
                         </div>
 
-                        <button type="button" class="w-100 btn btn-lg btn-primary">See Plans</button>
                     </div>
                 </div>
             </div>
@@ -356,9 +366,9 @@
                             <button class="btn btn-outline-info mx-auto d-block mt-3 fw-bold">Learn more</button>
                         </p>
 
-                        
+
                     </div>
-                  
+
                 </div>
             </div>
             <div class="col-sm-6 col-lg-4 mb-4" style="position: absolute; left: 50%; top: 0px;">
@@ -371,18 +381,18 @@
                             <br />
                                                         <i class="text-center d-block">Only limited by your imagination.</i>
 
-                            
+
                             <ul>
                                 <li>Any layouts</li>
                                 <li>Any business logic</li>
                                 <li>Quick development</li>
                             </ul>
 
-                          
-                            
+
+
                         </p>
 
-                        
+
                     </div>
                 </div>
             </div>
@@ -399,7 +409,7 @@
             </ul>
 
 
-                       
+
                     </div>
                          <hr class="my-0">
                          <div class="card-body text-center">
@@ -461,7 +471,7 @@
                           <li>Use "Rooms" to have self-contained real-time context.</li>
                           <li>Integrate WebSockets in some creative way yet not thought of</li>
                         </ul>
-                       
+
                     </div>
                 </div>
             </div>
@@ -483,6 +493,24 @@
                     </div>
                 </div>
             </div>
+                     <div class="col-sm-6 col-lg-4 mb-4" style="position: absolute; left: 0%; top: 823.999px;">
+                <div class="card text-start body-section">
+                    <div class="card-body">
+                        <h5 class="card-title text-center">Extensions and Plugins</h5>
+
+                        <p class="">Many programs have the feature offer plugin support, and I can do coding portion of making the plugin. 
+                            This may be able to help superpower your workflow with in a familiar program. </p>
+                            <p>
+                                
+                            </p>
+
+                        <h5>Examples</h5>
+                        <ul class="text-start" style="">
+                              <li>Browser Extensions</li>
+                         </ul>
+                    </div>
+                </div>
+            </div>
             <div class="col-sm-6 col-lg-4 mb-4" style="position: absolute; left: 50%; top: 937.999px;">
                 <div class="card body-section">
                     <div class="card-body">
@@ -495,6 +523,21 @@
                     </div>
                 </div>
             </div>
+            <div class="col-sm-6 col-lg-4 mb-4" style="position: absolute; left: 50%; top: 937.999px;">
+                <div class="card body-section">
+                    <div class="card-body">
+                        <h5 class="card-title">Data Visualizations</h5>
+                        <p>I can create charts that match your custom style. The visual output is a scalable vector graphic.</p>
+                        <ul id="data-vis-example">
+                           <li>Bar Graphs / Line Charts / <nobr> Donut Charts</nobr></li>
+                           <li>Scatter Plots / Heat Maps / Bubble Graphs</li>
+                           <li>Geographical Maps / Data over Maps</li>
+                            <li>Other diagrams</li>
+                        </ul>
+
+                </div>
+            </div>
+
         </div>
 
     </div>
@@ -503,7 +546,7 @@
 
 <div class="b-example-divider"></div>
 
-@* More svg def *@
+    @* More svg def *@
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <defs>
         <symbol id="check" viewBox="0 0 16 16" fill="currentColor">
@@ -517,7 +560,7 @@
     <div class="container body-section bg-body card">
 
 
-        @* Compare plans table *@
+            @* Compare plans table *@
         <div class="table-responsive container">
             <table class="table text-center">
                 <thead>
@@ -581,7 +624,7 @@
 <div class="wo-body-background">
 
     <div class="container body-section bg-body card">
-        @* Hero/Signup form *@
+            @* Hero/Signup form *@
         <div class="container px-4 py-5">
             <div class="row align-items-center g-lg-5 py-5">
                 <div class="col-lg-7 text-center text-lg-start">


### PR DESCRIPTION
- Adjusted padding of pricing plans section from `py-md-5` to `py-2`
- Updated radio button labels with detailed descriptions
- Removed the fourth, previously disabled, radio button
- Added new card sections for "Extensions and Plugins" and "Data Visualizations"
- Removed "See Plans" button from pricing plans section
- Cleaned up code by removing empty/redundant lines
- Added additional cards with specific positions and content
- Indented comments for "Compare plans table" and "Hero/Signup form"
- Made minor layout and positioning adjustments for better structure

closes #24 